### PR TITLE
Fix errors on empty lists being returned

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -110,6 +110,7 @@ impl BoardGameGeekApi {
     ) -> Result<T> {
         let response = self.send_request(request).await?;
         let response_text = response.text().await?;
+        println!("{response_text}");
 
         let parse_result = deserialise_xml_string(&response_text);
         match parse_result {

--- a/src/api.rs
+++ b/src/api.rs
@@ -110,7 +110,6 @@ impl BoardGameGeekApi {
     ) -> Result<T> {
         let response = self.send_request(request).await?;
         let response_text = response.text().await?;
-        println!("{response_text}");
 
         let parse_result = deserialise_xml_string(&response_text);
         match parse_result {

--- a/src/endpoints/collection_models.rs
+++ b/src/endpoints/collection_models.rs
@@ -17,7 +17,7 @@ pub struct Collection<T> {
     ///
     /// Note that accessories and games can never be returned together in one collection,
     /// but games and game expansions can.
-    #[serde(default = "Vec::new", rename = "$value")]
+    #[serde(default = "Vec::new", rename = "item")]
     pub items: Vec<T>,
 }
 
@@ -213,7 +213,6 @@ pub struct CollectionItemStatsBrief {
     pub owned_by: u64,
     /// Information about the rating that this user, as well as all users, have
     /// given this game.
-    #[serde(rename = "$value")]
     pub rating: CollectionItemRatingBrief,
 }
 
@@ -253,7 +252,7 @@ pub struct CollectionItemStats {
     pub owned_by: u64,
     /// Information about the rating that this user, as well as all users, have
     /// given this game.
-    #[serde(rename = "$value")]
+    #[serde(rename = "rating")]
     pub rating: CollectionItemRating,
 }
 

--- a/src/endpoints/game_family_models.rs
+++ b/src/endpoints/game_family_models.rs
@@ -10,7 +10,7 @@ use crate::{ItemType, NameType};
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct GameFamilies {
     /// List of game families, and the games that they contain.
-    #[serde(rename = "$value")]
+    #[serde(default, rename = "item")]
     pub game_families: Vec<GameFamily>,
 }
 

--- a/src/endpoints/game_models.rs
+++ b/src/endpoints/game_models.rs
@@ -14,57 +14,11 @@ use crate::utils::{
 use crate::{NameType, VersionsXml};
 
 // A struct containing the list of requested games with the full details.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize)]
 pub(crate) struct Games {
     // List of games.
+    #[serde(default, rename = "item")]
     pub(crate) games: Vec<GameDetails>,
-}
-
-impl<'de> Deserialize<'de> for Games {
-    fn deserialize<D: serde::de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        #[derive(Deserialize)]
-        #[serde(field_identifier, rename_all = "lowercase")]
-        enum Field {
-            TermsOfUse,
-            Script,
-            Item,
-        }
-
-        struct GamesVisitor;
-
-        impl<'de> serde::de::Visitor<'de> for GamesVisitor {
-            type Value = Games;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("an XML object for a list of board games returned by the `thing` endpoint from boardgamegeek")
-            }
-
-            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-            where
-                A: serde::de::MapAccess<'de>,
-            {
-                let mut games = vec![];
-                while let Some(key) = map.next_key()? {
-                    match key {
-                        Field::TermsOfUse => {
-                            // Consume and ignore
-                            map.next_value::<String>()?;
-                        },
-                        Field::Script => {
-                            // Sometimes there is an empty script tag before the list of items.
-                            // Nothing to do, skip past.
-                            map.next_value::<()>()?;
-                        },
-                        Field::Item => {
-                            games.push(map.next_value()?);
-                        },
-                    }
-                }
-                Ok(Self::Value { games })
-            }
-        }
-        deserializer.deserialize_any(GamesVisitor)
-    }
 }
 
 /// A game, or expansion, with full details.

--- a/src/endpoints/game_models.rs
+++ b/src/endpoints/game_models.rs
@@ -212,7 +212,6 @@ pub struct GameStats {
 // Structure of the stats tag in the returned XML
 #[derive(Debug, Deserialize)]
 struct XmlGameStats {
-    #[serde(rename = "$value")]
     ratings: StatsRatings,
 }
 
@@ -525,7 +524,7 @@ struct PollResults {
     #[serde(default, rename = "numplayers")]
     number_of_players: Option<PlayerCount>,
     // List of results.
-    #[serde(rename = "$value")]
+    #[serde(rename = "result")]
     results: Vec<PollResult>,
 }
 
@@ -548,7 +547,7 @@ struct PollResult {
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 struct VideosXml {
     // List of videos, each in an XML tag called `video`.
-    #[serde(rename = "$value")]
+    #[serde(rename = "video")]
     videos: Vec<Video>,
 }
 
@@ -715,8 +714,8 @@ impl<'de> Deserialize<'de> for Video {
 // nested list in the game details deserialise implementation
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 struct MarketplaceListingsXml {
-    // List of listings, each in an XML tag called `video`
-    #[serde(rename = "$value")]
+    // List of listings, each in an XML tag called `listing`
+    #[serde(rename = "listing")]
     listings: Vec<MarketplaceListing>,
 }
 
@@ -877,7 +876,7 @@ pub struct RatingCommentPage {
     #[serde(rename = "page")]
     pub page_number: u64,
     /// A list of members in this guid.
-    #[serde(rename = "$value")]
+    #[serde(rename = "comment")]
     pub comments: Vec<RatingComment>,
 }
 

--- a/src/endpoints/guild_models.rs
+++ b/src/endpoints/guild_models.rs
@@ -43,7 +43,7 @@ pub struct MemberPage {
     #[serde(rename = "page")]
     pub page_number: u64,
     /// A list of members in this guid.
-    #[serde(rename = "$value")]
+    #[serde(rename = "member")]
     pub members: Vec<Member>,
 }
 

--- a/src/endpoints/hot_list_models.rs
+++ b/src/endpoints/hot_list_models.rs
@@ -8,7 +8,7 @@ use crate::utils::{XmlSignedValue, XmlStringValue};
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct HotList {
     /// The list of trending board games currently on the hot list.
-    #[serde(rename = "$value")]
+    #[serde(default, rename = "item")]
     pub games: Vec<HotListGame>,
 }
 

--- a/src/endpoints/models.rs
+++ b/src/endpoints/models.rs
@@ -264,7 +264,7 @@ pub struct Dimensions {
 // Intermediary struct needed due to the way the XML is structured
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub(crate) struct XmlRanks {
-    #[serde(rename = "$value")]
+    #[serde(rename = "rank")]
     pub(crate) ranks: Vec<GameFamilyRank>,
 }
 
@@ -302,7 +302,7 @@ pub(crate) struct VersionsXml {
     // List of versions, each in an XML tag called `item`, within an outer
     // `version`. We use this intermediary type to get out just the first,
     // since we only expect 1.
-    #[serde(rename = "$value")]
+    #[serde(rename = "item")]
     pub(crate) versions: Vec<GameVersion>,
 }
 

--- a/src/endpoints/search_models.rs
+++ b/src/endpoints/search_models.rs
@@ -8,10 +8,8 @@ use crate::utils::{XmlSignedValue, XmlStringValue};
 /// The returned struct containing a list of search results.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct SearchResults {
-    // Must use serde default otherwise the empty results will return an error due to lack of
-    // `$value`
     /// The list of board games returned by the search.
-    #[serde(default, rename = "$value")]
+    #[serde(default, rename = "item")]
     pub results: Vec<SearchResult>,
 }
 

--- a/test_data/game_family/game_family_not_found.xml
+++ b/test_data/game_family/game_family_not_found.xml
@@ -1,0 +1,2 @@
+<items termsofuse="https://boardgamegeek.com/xmlapi/termsofuse">
+</items>


### PR DESCRIPTION
When looking for items of child tags if none can be found an error will be returned from deserialization. But since we are expecting a list, having 0 of them is valid.
 - Add default to vectors so that an empty vector is used when no items found.

The special value `$value` is used for all child tags. Remove all (bar one for an error) uses of `$value` for the actual tag name. This has a couple benefits:
- Won't cause us to error on unexpected children. Sometimes an empty `<script />` is returned and we don't have to handle that explicitly
- More clarity and readability

Revert games implementation back to derive deserialize